### PR TITLE
feat: NamespaceRemover ignore `xs:`

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,41 +122,43 @@ and namespace prefixes in attributes.
 ### Usage
 
 To use the `NamespaceRemover`, you need to create an instance of the class and call the appropriate method based on your
-needs. Here are some basic examples:
-
-#### Removing Namespaces from a String
+needs. Here is an example:
 
 ```kotlin
-val namespaceRemover = NamespaceRemover()
-val xmlString = "<root xmlns=\"http://www.example.com\"><child>text</child></root>"
-val result = namespaceRemover.apply(xmlString)
+val remover = NamespaceRemover()
+val xmlString = """
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://www.sample.com" targetNamespace="http://www.sample.com">
+        <xs:complexType name="complex">
+            <xs:sequence>
+                <xs:element name="simple" type="xs:string"/>
+            </xs:sequence>
+        </xs:complexType>
+        <xs:element name="sample" type="xs:string"/>
+        <xs:element name="complex" type="tns:complex"/>
+    </xs:schema>
+""".trimIndent()
+val result = remover.apply(xmlString)
+
+assert(
+    result == """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.sample.com">
+                    <xs:complexType name="complex">
+                        <xs:sequence>
+                            <xs:element name="simple" type="xs:string" />
+                        </xs:sequence>
+                    </xs:complexType>
+                    <xs:element name="sample" type="xs:string" />
+                    <xs:element name="complex" type="complex" />
+                </xs:schema>
+            """
+)
 ```
 
-In this example, `result` will be a `String` that contains the XML content of the processed string with all namespaces
-removed.
+Notice that the `tns` namespace prefix has been removed from the `complex` element type.
 
-#### Removing Namespaces from a File
-
-```kotlin
-val namespaceRemover = NamespaceRemover()
-val xmlFile = Paths.get("path/to/your/xml/file.xml")
-val result = namespaceRemover.process(xmlFile)
-```
-
-In this example, `result` will be a `String` that contains the XML content of the processed file with all namespaces
-removed.
-
-#### Removing Namespaces from a File and Writing to Another File
-
-```kotlin
-val namespaceRemover = NamespaceRemover()
-val inputFile = Paths.get("path/to/your/input/xml/file.xml")
-val outputFile = Paths.get("path/to/your/output/xml/file.xml")
-namespaceRemover.process(inputFile, outputFile)
-```
-
-In this example, the input file will be processed and the result (with all namespaces removed) will be written to the
-output file.
+**NOTE** The `NamespaceRemover` class does not remove the `xs` namespace prefix because it is a conventional namespace
+prefix for XML Schema.
 
 ## Chaining Xml Filters
 
@@ -203,10 +205,10 @@ The expected output will be:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" ?>
-<schema targetNamespace="http://www.sample.com">
-    <element name="sample" type="string"/>
-    <element name="sample_1" type="string"/>
-</schema>
+<xs:schema targetNamespace="http://www.sample.com">
+    <xs:element name="sample" type="string"/>
+    <xs:element name="sample_1" type="string"/>
+</xs:schema>
 ```
 
 In the output, you can see that the `sample_1` element from the included file `sample_1.xsd` has been inlined into the

--- a/src/test/kotlin/io/github/tacascer/namespace/NamespaceRemoverTest.kt
+++ b/src/test/kotlin/io/github/tacascer/namespace/NamespaceRemoverTest.kt
@@ -11,7 +11,7 @@ class NamespaceRemoverTest : FunSpec({
     context("given an XML with namespaces") {
         @Language("XML") val input = """
             <?xml version="1.0" encoding="UTF-8"?>
-            <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://www.sample.com" targetNamespace="http://www.sample.com">
+            <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://www.sample.com" xmlns:jaxb='http://java.sun.com/xml/ns/jaxb' targetNamespace="http://www.sample.com">
                 <xs:complexType name="complex">
                     <xs:sequence>
                         <xs:element name="simple" type="xs:string" />
@@ -19,6 +19,10 @@ class NamespaceRemoverTest : FunSpec({
                 </xs:complexType>
                 <xs:element name="sample" type="xs:string" />
                 <xs:element name="complex" type="tns:complex"/>
+                <jaxb:bindings>
+                    <jaxb:globalBindings>
+                    </jaxb:globalBindings>
+                </jaxb:bindings>
             </xs:schema>
             """.trimIndent()
 
@@ -33,6 +37,9 @@ class NamespaceRemoverTest : FunSpec({
                     </xs:complexType>
                     <xs:element name="sample" type="xs:string" />
                     <xs:element name="complex" type="complex" />
+                    <bindings>
+                        <globalBindings />
+                    </bindings>
                 </xs:schema>
                 
             """.trimIndent()
@@ -56,7 +63,7 @@ class NamespaceRemoverTest : FunSpec({
         context("compacted XML result") {
             @Language("XML") val expected = """
                 <?xml version="1.0" encoding="UTF-8"?>
-                <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.sample.com"><xs:complexType name="complex"><xs:sequence><xs:element name="simple" type="xs:string" /></xs:sequence></xs:complexType><xs:element name="sample" type="xs:string" /><xs:element name="complex" type="complex" /></xs:schema>
+                <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.sample.com"><xs:complexType name="complex"><xs:sequence><xs:element name="simple" type="xs:string" /></xs:sequence></xs:complexType><xs:element name="sample" type="xs:string" /><xs:element name="complex" type="complex" /><bindings><globalBindings /></bindings></xs:schema>
                 
             """.trimIndent()
 

--- a/src/test/kotlin/io/github/tacascer/namespace/NamespaceRemoverTest.kt
+++ b/src/test/kotlin/io/github/tacascer/namespace/NamespaceRemoverTest.kt
@@ -10,17 +10,30 @@ import kotlin.io.path.writeText
 class NamespaceRemoverTest : FunSpec({
     context("given an XML with namespaces") {
         @Language("XML") val input = """
-            <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.sample.com">
-                <xs:element name="sample" type="xs:string"/>
+            <?xml version="1.0" encoding="UTF-8"?>
+            <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://www.sample.com" targetNamespace="http://www.sample.com">
+                <xs:complexType name="complex">
+                    <xs:sequence>
+                        <xs:element name="simple" type="xs:string" />
+                    </xs:sequence>
+                </xs:complexType>
+                <xs:element name="sample" type="xs:string" />
+                <xs:element name="complex" type="tns:complex"/>
             </xs:schema>
-        """.trimIndent()
+            """.trimIndent()
 
         context("fully formatted XML result") {
             @Language("XML") val expected = """
                 <?xml version="1.0" encoding="UTF-8"?>
-                <schema targetNamespace="http://www.sample.com">
-                    <element name="sample" type="string" />
-                </schema>
+                <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.sample.com">
+                    <xs:complexType name="complex">
+                        <xs:sequence>
+                            <xs:element name="simple" type="xs:string" />
+                        </xs:sequence>
+                    </xs:complexType>
+                    <xs:element name="sample" type="xs:string" />
+                    <xs:element name="complex" type="complex" />
+                </xs:schema>
                 
             """.trimIndent()
 
@@ -36,19 +49,19 @@ class NamespaceRemoverTest : FunSpec({
 
                 NamespaceRemover().process(inputPath, outputPath)
 
-                outputPath.readText().replace("\r\n", "\n") shouldBe expected
+                outputPath.readText().lines().joinToString("\n") shouldBe expected
             }
         }
 
         context("compacted XML result") {
             @Language("XML") val expected = """
                 <?xml version="1.0" encoding="UTF-8"?>
-                <schema targetNamespace="http://www.sample.com"><element name="sample" type="string" /></schema>
+                <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.sample.com"><xs:complexType name="complex"><xs:sequence><xs:element name="simple" type="xs:string" /></xs:sequence></xs:complexType><xs:element name="sample" type="xs:string" /><xs:element name="complex" type="complex" /></xs:schema>
                 
             """.trimIndent()
 
             test("apply(String) should remove all namespaces") {
-                NamespaceRemover().apply(input).replace("\r\n", "\n") shouldBe expected
+                NamespaceRemover().apply(input).lines().joinToString("\n") shouldBe expected
             }
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated README with new examples and clarification on `NamespaceRemover` behavior.
- **New Features**
  - Enhanced `NamespaceRemover` to exclude the `xs` namespace prefix and improved logic for namespace handling.
- **Tests**
  - Expanded test cases to verify the updated behavior of namespace processing in XML schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->