### PR TITLE
ci: use Syft to upload SBOM for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,8 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
-      - name: Build
-        uses: gradle/gradle-build-action@v3
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
       - name: Publish
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{secrets.MAVEN_CENTRAL_USERNAME}}
@@ -22,24 +22,7 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{secrets.MAVEN_CENTRAL_GPG_KEY}}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{secrets.MAVEN_CENTRAL_GPG_PASSWORD}}
         run: ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache
-
-  upload-sbom:
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-      - name: Generate SBOM
-        run: |
-          curl -Lo $RUNNER_TEMP/sbom-tool https://github.com/microsoft/sbom-tool/releases/latest/download/sbom-tool-linux-x64
-          chmod +x $RUNNER_TEMP/sbom-tool
-          $RUNNER_TEMP/sbom-tool generate -b . -bc . -pn xml-processor -pv ${{github.ref_name}} -ps ${{github.repository_owner}} -nsb https://github.com/tacascer-org -V Verbose
-      - uses: actions/upload-artifact@v4
+      - name: Upload SBOM
+        uses: anchore/sbom-action@v0.15.11
         with:
-          name: sbom
-          path: _manifest/spdx_2.2
-      - name: SBOM upload
-        uses: advanced-security/spdx-dependency-submission-action@v0.0.1
-        with:
-          filePath: "_manifest/spdx_2.2/"
+          path: ./build/libs


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the setup process for Gradle.
	- Adjusted permissions for publishing jobs.
- **Refactor**
	- Modified the software bill of materials (SBOM) upload process in the release workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->